### PR TITLE
Include passing test cases for cops with zero offenses

### DIFF
--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -3,6 +3,11 @@ require 'rexml/document'
 module RuboCop
   module Formatter
     class JUnitFormatter < BaseFormatter
+
+      # This gives all cops - we really want all _enabled_ cops, but
+      # that is difficult to obtain - no access to config object here.
+      COPS = Cop::Cop.all
+      
       def started(target_file)
         @document = REXML::Document.new.tap do |d|
           d << REXML::XMLDecl.new
@@ -16,14 +21,17 @@ module RuboCop
       def file_finished(file, offences)
         return if offences.empty?
 
-        offences.group_by(&:cop_name).each do |cop, cop_offences|
+        # One test case per cop per file
+        COPS.each do |cop|
           REXML::Element.new('testcase', @testsuite).tap do |f|
             f.attributes['classname'] = file.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').gsub('/', '.')
-            f.attributes['name']      = cop
-
-            cop_offences.each do |offence|
+            f.attributes['name']      = cop.cop_name
+            
+            # One failure per offence.  Zero failures is a passing test case,
+            # for most surefire/nUnit parsers.
+            offences.select {|offence| offence.cop_name == cop.cop_name}.each do |offence|
               REXML::Element.new('failure', f).tap do |e|
-                e.attributes['type'] = cop
+                e.attributes['type'] = cop.cop_name
                 e.attributes['message'] = offence.message
                 e.add_text offence.location.to_s
               end


### PR DESCRIPTION
Refs #2.

Provides a way to have a consistent number of test cases over time (or at least tied to the underlying version of rubocop), while you can see your number of failed test cases vary over time.
