### PR TITLE
Emit all test cases for passing files

### DIFF
--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -19,8 +19,6 @@ module RuboCop
       end
 
       def file_finished(file, offences)
-        return if offences.empty?
-
         # One test case per cop per file
         COPS.each do |cop|
           REXML::Element.new('testcase', @testsuite).tap do |f|


### PR DESCRIPTION
If a file passes the Rubocop check, we should emit passes for all the Cops that are checked. This ensures that we have a consistent number of tests for the same number of files.

Otherwise, we cannot turn on checks on the CI to fail builds if the number of tests varies too drastically.
