### PR TITLE
Update junit_formatter.rb

### DIFF
--- a/lib/rubocop/formatter/junit_formatter.rb
+++ b/lib/rubocop/formatter/junit_formatter.rb
@@ -3,7 +3,7 @@ require 'rexml/document'
 module RuboCop
   module Formatter
     class JUnitFormatter < BaseFormatter
-
+      
       # This gives all cops - we really want all _enabled_ cops, but
       # that is difficult to obtain - no access to config object here.
       COPS = Cop::Cop.all
@@ -15,32 +15,61 @@ module RuboCop
         @testsuites = REXML::Element.new('testsuites', @document)
         @testsuite = REXML::Element.new('testsuite', @testsuites).tap do |el|
           el.add_attributes('name' => 'rubocop')
+          el.add_attributes('timestamp' => Time.now.getutc)
         end
       end
 
+      $suitetests = 0
+      $suitetestfailures = 0
       def file_finished(file, offences)
+        testcasetests = 0
+        testcasefailures = 0
+        testcaseoffenses = 0
+        lastcopname = ''
         # One test case per cop per file
         COPS.each do |cop|
           REXML::Element.new('testcase', @testsuite).tap do |f|
             f.attributes['classname'] = file.gsub(/\.rb\Z/, '').gsub("#{Dir.pwd}/", '').gsub('/', '.')
             f.attributes['name']      = cop.cop_name
-            
+            testcasetests = testcasetests += 1            
             # One failure per offence.  Zero failures is a passing test case,
             # for most surefire/nUnit parsers.
             offences.select {|offence| offence.cop_name == cop.cop_name}.each do |offence|
               REXML::Element.new('failure', f).tap do |e|
                 e.attributes['type'] = cop.cop_name
                 e.attributes['message'] = offence.message
-                e.add_text offence.location.to_s
+                path = Pathname.new(file).relative_path_from(Pathname.new(Dir.pwd))
+                e.add_text "#{path.to_s}:#{offence.line.to_s}:#{offence.real_column}"
               end
+              if (cop.cop_name != lastcopname )
+                lastcopname = "#{cop.cop_name}"
+                testcasefailures = testcasefailures += 1
+              end
+              testcaseoffenses = testcaseoffenses += 1                           
             end
           end
+        end
+        $suitetests = $suitetests + testcasetests
+        $suitetestfailures = $suitetestfailures + testcasefailures
+        @testsuite.tap do |el|
+          el.add_attributes('tests' => $suitetests)
+          el.add_attributes('failures' => $suitetestfailures)
+        end
+        if testcaseoffenses == 0
+          REXML::Element.new('testcase', @testsuite).tap do |s|
+            s.add_attributes('name' => "There were #{testcaseoffenses} offences out of #{testcasetests}. All tests passed.")
+          end
+        else
+          REXML::Element.new('testcase', @testsuite).tap do |s|            
+            s.add_attributes('name' => "There were #{testcaseoffenses} offences in #{testcasefailures} failed tests out of #{testcasetests}.")
+          end                  
         end
       end
 
       def finished(inspected_files)
         @document.write(output, 2)
       end
+
     end
   end
 end

--- a/rubocop-junit-formatter.gemspec
+++ b/rubocop-junit-formatter.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-junit-formatter"
-  spec.version       = '0.1.3'
+  spec.version       = '0.1.4'
   spec.authors       = ["Mikko Kokkonen"]
   spec.email         = ["mikko@mikian.com"]
   spec.summary       = %q{Outputs RuboCop Offences as JUnit report}


### PR DESCRIPTION
Not sure if I'm submitting this PR correctly, but here goes. As I was looking for something a bit more from the junit formatter, I noticed the PR submitted by SubatomicHero that wasn't approved mainly due to formatting. While trying to put those changes into an easier to understand formatting (for looking at the PR change window I assume), I noticed that it looked like some of the number counts didn't actually work... So I fiddled with it a bit and setup counters for # of testsuite cases, # of testsuite failures,  # of offenses/per file as well as expanding the  per file summary to summarize for all files and not just zero offenses.  I also made it so the filename listed for the offense is relative vs absolute. Hope this helps. I also submitted basically this same PR to SubAtomicHero since I based this on his work.